### PR TITLE
Do not mutate current directory for plugin

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -36,8 +36,8 @@
 
 (defun import-js-send-input (&rest opts)
   (let ((path buffer-file-name)
-        (temp-buffer (generate-new-buffer "import-js")))
-    (cd (shell-quote-argument import-js-project-root))
+        (temp-buffer (generate-new-buffer "import-js"))
+        (default-directory import-js-project-root))
     (apply 'call-process `("importjs"
                            ,path
                            ,temp-buffer


### PR DESCRIPTION
Fixes #4 
### Before

Currently this plugin uses `cd` to change the working directory, which
has the side effect of leaving the directory changed after running. This
causes problems such as #4.
### After

Now uses `default-directory` in a `let` scope, which `call-process` uses
as its working directory.
