### PR TITLE
Handle some goto cases in which blank buffers are opened

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -74,7 +74,20 @@
   (interactive)
   (let ((goto-list (json-read-from-string
                     (import-js-send-input "goto" (import-js-word-at-point)))))
-    (find-file (cdr (assoc 'goto goto-list)))))
+    (find-file (import-js-locate-goto-file (cdr (assoc 'goto goto-list))))))
+
+(defun import-js-locate-goto-file (goto-value)
+  (let ((goto-file goto-value))
+    (if (file-name-absolute-p goto-value)
+        (let ((goto-located nil)
+              (js-suffixes '(".js" ".jsx")))
+          (if (file-directory-p goto-value)
+              (setf goto-located (locate-file "index" `(,goto-value) js-suffixes))
+            (setf goto-located (locate-file goto-value '("/") js-suffixes)))
+
+          (if goto-located (setf goto-file goto-located))))
+
+    goto-file))
 
 (provide 'import-js)
 ;;; import-js.el ends here


### PR DESCRIPTION
Fix goto-value in cases it is a absolute path **without suffix**.
Given this dir layout:
```
  App.js
  configureStore.js
  components/
  ├── EbookPage.js
  ├── MePage.js
  ├── QuestionPage.js
  └── TabIcon.js
  containers/
  └── Root.js
  actions/
  └── ebooks.js
  reducers/
  ├── ebooks.js
  └── index.js
```
cases below should **work as expected**:
* `import App from '../App'` in containers/Root.js, goto App, open App.js 
* `import EbookList from './components/EbookPage'` in App.js, goto EbookList, open components/EbookPage.js
* `import { fetchEbooks } from '../actions/ebooks'` in components/EbookPage.js, goto fetchEbooks, open actions/ebooks.js
* `import rootReducer from './reducers'` in configureStore.js, goto rootReducer, open reducers/index.js 
