### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -4,7 +4,7 @@
 ;; Author: Kevin Kehl <kevin.kehl@gmail.com>
 ;; URL: http://github.com/Galooshi/emacs-import-js/
 ;; Package-Requires: ((emacs "24"))
-;; Version: 0.1.0
+;; Version: 0.7.0
 ;; Keywords: javascript
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
MELPA stable somehow got tagged as v0.6.0, so bumping it above to ensure
the latest gets pushed to stable.

Before releasing 1.0.0, we need to fix
https://github.com/Galooshi/emacs-import-js/issues/2
which would allow selection of components that have name collisions.