### PR TITLE
Add grizzl as dependency in comment metadata

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -3,7 +3,7 @@
 ;;
 ;; Author: Kevin Kehl <kevin.kehl@gmail.com>
 ;; URL: http://github.com/Galooshi/emacs-import-js/
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((grizzl "0.1.0") (emacs "24"))
 ;; Version: 0.7.0
 ;; Keywords: javascript
 


### PR DESCRIPTION
Installing clean did not add the dependency on grizzl. I've noticed that
other packages have these in their requirements, and package.el seems to
be using this as metadata, so try to add here and see if package.el picks
it up.

I finally found some more info in the docs: https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html