### PR TITLE
Add handling for multiple unresolved imports

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -4,7 +4,7 @@
 ;; Author: Kevin Kehl <kevin.kehl@gmail.com>
 ;; URL: http://github.com/Galooshi/emacs-import-js/
 ;; Package-Requires: ((grizzl "0.1.0") (emacs "24"))
-;; Version: 0.7.0
+;; Version: 1.0.0
 ;; Keywords: javascript
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
This allows us to release @ 1.0.0, since we now handle the base import-js behaviors.

Closes https://github.com/Galooshi/emacs-import-js/issues/2

cc @trotzig @lencioni 