### PR TITLE
Use importjsd instead of importjs CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
   * Alternatively, Copy plugins/import-js.el into your Emacs load-path and add
     `(require 'import-js)` to your config. You will also need to install
     [grizzl](https://github.com/grizzl/grizzl)
-4. Configure your project root
-  * `(setq import-js-project-root "/path/to/project")`
+4. Run the import-js daemon
+  * `(M-x) run-import-js`
+  * The daemon will use watchman if installed to improve performance
 5. Import a file!
   * You can use something like `(M-x) import-js-import` with your cursor over
     the desired module


### PR DESCRIPTION
Version 2.1.0 of core import-js introduced some additional functionality
that only works in the daemon version. We also prefer the daemon process
version, because it is much faster (as it doesn't have to initialize a
node.js runtime). We can also take advantage of watchman if installed
locally.

This version of emacs-import-js removes support for using the import-js
CLI.