### PR TITLE
Fix import-js breaking when json-encoding-pretty-print is set

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -42,10 +42,15 @@
   (unless import-js-process
     (throw 'import-js-daemon "import-js-daemon not running")))
 
+(defun import-js-json-encode-alist (alist)
+  (let ((json-encoding-pretty-print nil))
+    (json-encode-alist alist)))
+
 (defun import-js-send-input (input-alist)
   "Append the current buffer content and path to file to a data alist, and send to import-js"
-  (let ((input-json (json-encode-alist (append input-alist `(("fileContent" . ,(buffer-string))
-                                                             ("pathToFile" . ,(buffer-file-name)))))))
+  (let ((input-json (import-js-json-encode-alist (append input-alist
+                                                         `(("fileContent" . ,(buffer-string))
+                                                           ("pathToFile" . ,(buffer-file-name)))))))
     (process-send-string import-js-process input-json)
     (process-send-string import-js-process "\n")))
 


### PR DESCRIPTION
IPC is broken when `json-encoding-pretty-print` is set, because `import-js` reads input via `readline` and there'll be linebreaks in the json when pretty-printing.

Wrap the call to `json-encode-alist` to always set`json-encoding-pretty-print` to nil.