### PR TITLE
Remove save-some-buffers

### DIFF
--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -131,7 +131,6 @@
 (defun import-js-import ()
   "Run import-js on a particular module"
   (interactive)
-  (save-some-buffers)
   (import-js-check-daemon)
   (setq import-js-output "")
   (setq import-js-handler 'import-js-handle-imports)
@@ -142,7 +141,6 @@
 (defun import-js-fix ()
   "Run import-js on an entire file, importing or fixing as necessary"
   (interactive)
-  (save-some-buffers)
   (import-js-check-daemon)
   (setq import-js-output "")
   (setq import-js-handler 'import-js-handle-imports)


### PR DESCRIPTION
Users might want to hook import-js-fix using either `after-save-hook` or `before-save-hook`.

Signed-off-by: Huy Duong <huy.duong@employmenthero.com>