### PR TITLE
Use Emacs' built-in completing-read instead of Grizzl

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 3. Install import-js.el for Emacs
   * Install via [MELPA](https://melpa.org/#/import-js)
   * Alternatively, Copy plugins/import-js.el into your Emacs load-path and add
-    `(require 'import-js)` to your config. You will also need to install
-    [grizzl](https://github.com/grizzl/grizzl)
+    `(require 'import-js)` to your config.
 4. Run the import-js daemon
   * `(M-x) run-import-js`
   * The daemon will use watchman if installed to improve performance

--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -3,7 +3,7 @@
 ;;
 ;; Author: Kevin Kehl <kevin.kehl@gmail.com>
 ;; URL: http://github.com/Galooshi/emacs-import-js/
-;; Package-Requires: ((grizzl "0.1.0") (emacs "24"))
+;; Package-Requires: ((emacs "24"))
 ;; Version: 1.0.0
 ;; Keywords: javascript
 
@@ -29,9 +29,6 @@
 ;;; Code:
 
 (require 'json)
-
-(eval-when-compile
-  (require 'grizzl))
 
 (defvar import-js-handler nil "Current import-js output handler")
 (defvar import-js-handler-buffer nil "Current import-js buffer to write to when handler is invoked.")
@@ -91,18 +88,18 @@
 
 (defun import-js-handle-unresolved (unresolved word)
   "Map unresolved imports to a path"
-  (let ((paths (mapcar
-                (lambda (car)
-                  (cdr (assoc 'importPath car)))
-                (cdr (assoc-string word unresolved)))))
-    (minibuffer-with-setup-hook
-        (lambda () (make-sparse-keymap))
-      (grizzl-completing-read (format "Unresolved import (%s)" word)
-                              (grizzl-make-index
-                               paths
-                               'files
-                               import-js-current-project-root
-                               nil)))))
+  (let* ((unresolvedImports (cdr (assoc-string word unresolved)))
+         (collection (mapcar
+                      (lambda (car)
+                        (list
+                         (cdr (assoc 'displayName car))
+                         (cdr (assoc 'importPath car))))
+                      unresolvedImports)))
+    (cadr (assoc
+           (completing-read
+            (format "Unresolved import (%s)" word)
+            collection)
+           collection))))
 
 (defun import-js-handle-data (process data)
   "Handles STDOUT from node, which arrives in chunks"


### PR DESCRIPTION
The [Grizzl](https://github.com/grizzl/grizzl) project is deprecated. I replaced its use with the built-in `completing-read`. This way users can install their completing-read package of choice and it will be used automatically by `import-js`.